### PR TITLE
Default scope problem

### DIFF
--- a/gemfiles/rails2.gemfile.lock
+++ b/gemfiles/rails2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/mgrosser/code/tools/soft_deletion
+  remote: /Users/michel/ruby/fidzup/soft_deletion
   specs:
-    soft_deletion (0.1.2)
+    soft_deletion (0.1.3)
 
 GEM
   remote: http://rubygems.org/

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: /Users/mgrosser/code/tools/soft_deletion
+  remote: /Users/michel/ruby/fidzup/soft_deletion
   specs:
-    soft_deletion (0.1.2)
+    soft_deletion (0.1.3)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/soft_deletion.rb
+++ b/lib/soft_deletion.rb
@@ -8,7 +8,12 @@ module SoftDeletion
       raise "You can only include this if #{base} extends ActiveRecord::Base"
     end
     base.extend(ClassMethods)
-    base.send(:default_scope, :conditions => base.soft_delete_default_scope_conditions)
+
+    # Avoids a bad SQL request with versions of code without the colun deleted_at (for example a migration prior to the migration
+    # that adds deleted_at)
+    if base.column_names.include?('deleted_at')
+      base.send(:default_scope, :conditions => base.soft_delete_default_scope_conditions)
+    end
 
     # backport after_soft_delete so we can safely upgrade to rails 3
     if ActiveRecord::VERSION::MAJOR > 2

--- a/test/soft_deletion_test.rb
+++ b/test/soft_deletion_test.rb
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :categories do |t|
     t.timestamp :deleted_at
   end
+
+  create_table :original_categories do |t|
+  end
 end
 
 class ActiveRecord::Base
@@ -45,31 +48,35 @@ end
 
 # No association
 class NACategory < ActiveRecord::Base
-  include SoftDeletion
   silent_set_table_name 'categories'
+  include SoftDeletion
 end
 
 # Independent association
 class IDACategory < ActiveRecord::Base
-  include SoftDeletion
   silent_set_table_name 'categories'
+  include SoftDeletion
   has_many :forums, :dependent => :destroy, :foreign_key => :category_id
 end
 
 # Nullified dependent association
 class NDACategory < ActiveRecord::Base
-  include SoftDeletion
   silent_set_table_name 'categories'
+  include SoftDeletion
   has_many :forums, :dependent => :destroy, :foreign_key => :category_id
 end
 
 # Has ome association
 class HOACategory < ActiveRecord::Base
-  include SoftDeletion
   silent_set_table_name 'categories'
+  include SoftDeletion
   has_one :forum, :dependent => :destroy, :foreign_key => :category_id
 end
 
+# Class without column deleted_at
+class OriginalCategory < ActiveRecord::Base
+  include SoftDeletion
+end
 
 def clear_callbacks(model, callback)
   if ActiveRecord::VERSION::MAJOR > 2
@@ -212,6 +219,14 @@ class SoftDeletionTest < ActiveSupport::TestCase
       category.soft_delete!
       assert_deleted forum
       #assert_nil forum.category_id # TODO
+    end
+  end
+
+  context 'without deleted_at column' do
+    should 'default scope should not provoke an error' do
+      assert_nothing_raised do
+        OriginalCategory.create!
+      end
     end
   end
 end


### PR DESCRIPTION
I had migrations created a few days ago that did not execute after including the module. So I modified it to not using the default scope without the column deleted_at.
