### PR TITLE
Stop execution chain if a before_callback returns false.

### DIFF
--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -8,16 +8,7 @@ module SoftDeletion
 
       # backport after_soft_delete so we can safely upgrade to rails 3
       if ActiveRecord::VERSION::MAJOR > 2
-        base.define_callbacks :soft_delete
-        class << base
-          def before_soft_delete(*callbacks, &block)
-            set_callback :soft_delete, :before, *callbacks, &block
-          end
-
-          def after_soft_delete(*callbacks, &block)
-            set_callback :soft_delete, :after, *callbacks, &block
-          end
-        end
+        base.define_model_callbacks :soft_delete
       else
         base.define_callbacks :before_soft_delete
         base.define_callbacks :after_soft_delete
@@ -106,7 +97,7 @@ module SoftDeletion
             result = block.call
           end
         else
-          run_callbacks :before_soft_delete
+          return false if !run_callbacks(:before_soft_delete) { |result, object| result == false }
           mark_as_deleted
           soft_delete_dependencies.each(&:soft_delete!)
           result = block.call

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -43,6 +43,7 @@ describe SoftDeletion do
     # Stub dump method calls
     Category.any_instance.stub(:foo)
     Category.any_instance.stub(:bar)
+    Category.any_instance.stub(:baz) {  false }
   end
 
   describe "callbacks" do
@@ -54,6 +55,15 @@ describe SoftDeletion do
         category.should_receive(:foo)
 
         category.soft_delete!
+      end
+
+      it "should stop execution chain if false is returned" do
+        Category.before_soft_delete :baz
+        category = Category.create!
+
+        category.soft_delete!
+        category.reload
+        category.should_not be_deleted
       end
     end
 


### PR DESCRIPTION
Also changes over to use define_model_callbaks in rails 3 which honors the same behavior and adds 'before', 'around', and 'after' callbacks.

@grosser please take a look and see if all is ok :)
