### PR TITLE
pass default_scope a lambda for Rails 4 compability

### DIFF
--- a/lib/soft_deletion/setup.rb
+++ b/lib/soft_deletion/setup.rb
@@ -24,7 +24,7 @@ module SoftDeletion
         if options[:default_scope] && table_exists? && column_names.include?("deleted_at")
           # Avoids a bad SQL request with versions of code without the column deleted_at (for example a migration prior to the migration
           # that adds deleted_at)
-          default_scope -> { where(:deleted_at => nil) }
+          default_scope lambda { where(:deleted_at => nil) }
         end
       end
     end


### PR DESCRIPTION
In Rails 4 all ActiveRecord scopes must be defined with a callable object (i.e. Proc or lambda).  This commit will remove the warning.

DEPRECATION WARNING: Calling #scope or #default_scope with a hash is deprecated. Please use a lambda containing a scope. E.g. scope :red, -> { where(color: 'red') }. (called from has_soft_deletion at /usr/local/rvm/gems/ruby-2.0.0-p247@global/bundler/gems/soft_deletion-bcba8464d3c4/lib/soft_deletion/setup.rb:27)
