### PR TITLE
Do not changed deleted_at timestamp if already soft deleted

### DIFF
--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -72,7 +72,7 @@ module SoftDeletion
     end
 
     def mark_as_deleted
-      self.deleted_at = Time.now
+      self.deleted_at = Time.now unless self.deleted?
     end
 
     def mark_as_undeleted

--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -72,7 +72,7 @@ module SoftDeletion
     end
 
     def mark_as_deleted
-      self.deleted_at = Time.now unless self.deleted?
+      self.deleted_at ||= Time.now
     end
 
     def mark_as_undeleted

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -507,7 +507,7 @@ describe SoftDeletion do
       forum.should be_deleted
     end
 
-    it "should not change updated_at if already soft deleted" do
+    it "should not change deleted_at if already soft deleted" do
       forum = ValidatedForum.create!(:category_id => 1)
 
       forum.soft_delete.should == true

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -506,5 +506,17 @@ describe SoftDeletion do
       forum.reload
       forum.should be_deleted
     end
+
+    it "should not change updated_at if already soft deleted" do
+      forum = ValidatedForum.create!(:category_id => 1)
+
+      forum.soft_delete.should == true
+      forum.reload
+      deleted_at = forum.deleted_at
+
+      forum.soft_delete.should == true
+      forum.reload
+      forum.deleted_at.should eq(deleted_at)
+    end
   end
 end


### PR DESCRIPTION
Do not change deleted_at timestamp when soft deleting an object is already soft deleted.

This came up during an large import job where a customer ended up continually updating a custom dropdown field and inadvertently creating thousands of soft deleted fields. Each subsequent update would alter the deleted_at and force re-saving of the custom field and would eventually cause database timeouts.

This could be fixed at the point where the soft deletion occurs in the custom field but it seemed like fixing at the source would be better.