### PR TITLE
soft_delete! passes args to save!, e.g. validate: false

### DIFF
--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    soft_deletion (0.7.0)
+    soft_deletion (0.8.2)
       activerecord (>= 3.2.0, < 5.1.0)
 
 GEM
@@ -58,4 +58,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/gemfiles/rails4.1.gemfile.lock
+++ b/gemfiles/rails4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    soft_deletion (0.7.0)
+    soft_deletion (0.8.2)
       activerecord (>= 3.2.0, < 5.1.0)
 
 GEM
@@ -59,4 +59,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    soft_deletion (0.8.0)
+    soft_deletion (0.8.2)
       activerecord (>= 3.2.0, < 5.1.0)
 
 GEM
@@ -59,4 +59,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    soft_deletion (0.8.0)
+    soft_deletion (0.8.2)
       activerecord (>= 3.2.0, < 5.1.0)
 
 GEM
@@ -56,4 +56,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -72,8 +72,8 @@ module SoftDeletion
       self.deleted_at = nil
     end
 
-    def soft_delete!
-      _run_soft_delete { save! } || soft_delete_hook_failed(:before_soft_delete)
+    def soft_delete!(*args)
+      _run_soft_delete { save!(*args) } || soft_delete_hook_failed(:before_soft_delete)
     end
 
     def soft_delete(*args)

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -504,8 +504,9 @@ describe SoftDeletion do
   end
 
   describe "validations" do
+    let(:forum) { ValidatedForum.create!(category_id: 1) }
+
     it "fails when validations fail" do
-      forum = ValidatedForum.create!(:category_id => 1)
       forum.category_id = nil
 
       expect do
@@ -517,8 +518,15 @@ describe SoftDeletion do
     end
 
     it "passes when validations pass" do
-      forum = ValidatedForum.create!(:category_id => 1)
       forum.soft_delete!
+
+      forum.reload
+      forum.should be_deleted
+    end
+
+    it "can skip validations" do
+      forum.category_id = nil
+      forum.soft_delete!(validate: false)
 
       forum.reload
       forum.should be_deleted


### PR DESCRIPTION
The `soft_delete` method already accepted a splat of args and passed them to `save`. This provides parity to `soft_delete!` passing args to `save!`. My general use case is that when old records have drifted out of new validations, I generally don't care to apply those validations when soft deleting a record.

/cc @grosser 