### PR TITLE
When association is nullifying on soft delete it now uses `.update_all`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,7 +48,6 @@ User.soft_delete_all!(1,2,3,4)
 
 TODO
 ====
- - nullify should use update_all on has_many on soft_delete (performance)
  - has_many :through should delete join associations on soft_delete
  - cascading soft_deletes should use the same timestamp for easy reverts
 

--- a/lib/soft_deletion/dependency.rb
+++ b/lib/soft_deletion/dependency.rb
@@ -10,7 +10,7 @@ module SoftDeletion
     def execute_soft_delete(method, args)
       case association.options[:dependent]
       when :nullify
-        nullify_dependencies
+        dependency.update_all(association.foreign_key => nil)
       when :delete_all
         dependency.update_all(dependency.mark_as_soft_deleted_sql)
         true
@@ -26,12 +26,6 @@ module SoftDeletion
     end
 
     protected
-
-    def nullify_dependencies
-      dependencies.each do |dependency|
-        dependency.update_column(association.foreign_key, nil)
-      end
-    end
 
     def klass
       association.klass


### PR DESCRIPTION
nullify should use update_all on has_many on soft_delete (performance). Done!