### PR TITLE
Add rails `7.2.0` support

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.1', '3.2', '3.3']
-        rails: ['6.1', '7.0', '7.1']
+        rails: ['6.1', '7.0', '7.1', '7.2']
         exclude:
           - ruby: '3.2'
             rails: '6.1'

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     soft_deletion (1.9.0)
-      activerecord (>= 5.0.0, < 7.2)
+      activerecord (>= 5.0.0, < 7.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     soft_deletion (1.9.0)
-      activerecord (>= 5.0.0, < 7.2)
+      activerecord (>= 5.0.0, < 7.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     soft_deletion (1.9.0)
-      activerecord (>= 5.0.0, < 7.2)
+      activerecord (>= 5.0.0, < 7.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 7.2.0"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     soft_deletion (1.9.0)
       activerecord (>= 5.0.0, < 7.3)
@@ -32,43 +32,52 @@ GEM
     connection_pool (2.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
-    database_cleaner-active_record (2.1.0)
+    database_cleaner-active_record (2.2.0)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     drb (2.2.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     logger (1.6.0)
-    mini_portile2 (2.8.7)
     minitest (5.24.1)
-    rake (13.1.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rake (13.2.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     securerandom (0.3.1)
     single_cov (1.11.0)
-    sqlite3 (1.7.3)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
+  activerecord (~> 7.2.0)
   bump
   byebug
   database_cleaner (>= 1.5.1)
@@ -76,7 +85,7 @@ DEPENDENCIES
   rspec (~> 3.5)
   single_cov
   soft_deletion!
-  sqlite3
+  sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.3.12
+   2.5.15

--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -86,12 +86,24 @@ module SoftDeletion
 
     protected
 
-    def update_soft_delete_counter_caches(value)
-      each_counter_cached_associations do |association|
-        association.load_target unless association.loaded?
-        if (target = association.target) # uncovered TODO: add test coverage for target not existing
-          target.class.update_counters(target.id, association.reflection.counter_cache_column => value)
+    if ActiveRecord.version >= Gem::Version.new("7.2.0")
+      def update_soft_delete_counter_caches(value) # uncovered NOTE: covered only at Rails >= 7.2.0 tests
+        counter_cached_association_names.each do |association_name| # uncovered
+          update_soft_delete_counter_cache(association(association_name), value) # uncovered
         end
+      end
+    else
+      def update_soft_delete_counter_caches(value) # uncovered NOTE: covered only at Rails < 7.2.0 tests
+        each_counter_cached_associations do |association| # uncovered
+          update_soft_delete_counter_cache(association, value) # uncovered
+        end
+      end
+    end
+
+    def update_soft_delete_counter_cache(association, value)
+      association.load_target unless association.loaded?
+      if (target = association.target) # uncovered TODO: add test coverage for target not existing
+        target.class.update_counters(target.id, association.reflection.counter_cache_column => value)
       end
     end
 

--- a/soft_deletion.gemspec
+++ b/soft_deletion.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new name, SoftDeletion::VERSION do |s|
   s.files = `git ls-files lib Readme.md`.split("\n")
   s.license = "MIT"
   s.required_ruby_version = '>= 2.7.0'
-  s.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 7.2'
+  s.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 7.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
The only non-compatible ActiveRecord's change I was able to find is removal of private `each_counter_cached_associations` method (see https://github.com/rails/rails/pull/49866). After applying the fix out internal test suite was fine.

By the way, MRI 2.7 EOLed 4 years ago -- I think it'd fine to drop support for it.