### PR TITLE
update_timestamp option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,13 +66,13 @@ class AddDeletedAtToUsers < ActiveRecord::Migration[6.0]
 end
 ```
 
-By default `soft_deletion` does not change the `updated_at` value in the record. If you need this feature, you can use the `update_timestamp` option:
+By default `soft_deletion` does not change the `updated_at` value in the record. If you need this feature, you can use the `update_timestamp` option, passing the name of the column holding the timestamp to be updated, like, for example, `updated_at`:
 
 ```Ruby
 require 'soft_deletion'
 
 class User < ActiveRecord::Base
-  has_soft_deletion update_timestamp: true
+  has_soft_deletion update_timestamp: :updated_at
 end
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,17 @@ class AddDeletedAtToUsers < ActiveRecord::Migration[6.0]
 end
 ```
 
+By default `soft_deletion` does not change the `updated_at` value in the record. If you need this feature, you can use the `update_timestamp` option:
+
+```Ruby
+require 'soft_deletion'
+
+class User < ActiveRecord::Base
+  has_soft_deletion update_timestamp: true
+end
+```
+
+
 TODO
 ====
  - has_many :through should delete join associations on soft_delete

--- a/lib/soft_deletion/core.rb
+++ b/lib/soft_deletion/core.rb
@@ -33,7 +33,7 @@ module SoftDeletion
 
       def mark_as_soft_deleted_sql
         t = Time.now
-        if self.try(:soft_deletion_update_timestamp)
+        if self.soft_deletion_update_timestamp
           { deleted_at: t, updated_at: t }
         else
           { deleted_at: t }
@@ -68,11 +68,9 @@ module SoftDeletion
 
     def mark_as_deleted
       t = Time.now
-      if self.class.try(:soft_deletion_update_timestamp)
-        self.deleted_at ||= Time.now
+      self.deleted_at ||= t
+      if self.class.soft_deletion_update_timestamp
         self.updated_at = [self.deleted_at, self.updated_at].compact.max
-      else
-        self.deleted_at ||= Time.now
       end
     end
 

--- a/lib/soft_deletion/setup.rb
+++ b/lib/soft_deletion/setup.rb
@@ -27,6 +27,8 @@ module SoftDeletion
             end
           end
         end
+
+        self.soft_deletion_update_timestamp = options[:update_timestamp]
       end
     end
   end

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -32,7 +32,7 @@ describe SoftDeletion do
         category.soft_delete!
         category.reload
         expect(category).to be_deleted
-        expect(category.updated_at).not_to eq original_updated_at
+        expect(category.updated_at).to be >= original_updated_at
       end
     end
   end
@@ -67,7 +67,7 @@ describe SoftDeletion do
       end
 
       it "updates the timestamp" do
-        expect(@timestamp_category.updated_at).not_to eq @original_updated_at
+        expect(@timestamp_category.updated_at).to be >= @original_updated_at
       end
     end
   end

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -22,6 +22,19 @@ describe SoftDeletion do
         expect(@forum).to be_deleted
       end
     end
+
+    context "with update_timestamp option" do
+      it "removes the record and updates the timestamp" do
+        original_updated_at = Time.now - 2.years
+        category = TimestampCategory.create!(updated_at: original_updated_at)
+        expect(category.updated_at).to eq original_updated_at
+
+        category.soft_delete!
+        category.reload
+        expect(category).to be_deleted
+        expect(category.updated_at).not_to eq original_updated_at
+      end
+    end
   end
 
   def self.successfully_bulk_soft_deletes
@@ -38,6 +51,23 @@ describe SoftDeletion do
       it "soft deletes its dependent associations" do
         @forum.reload
         expect(@forum).to be_deleted
+      end
+    end
+
+    context "with update_timestamp option" do
+      before do
+        @original_updated_at = Time.now - 2.years
+        @timestamp_category = TimestampCategory.create!(updated_at: @original_updated_at)
+        TimestampCategory.soft_delete_all!(@timestamp_category)
+        @timestamp_category.reload
+      end
+
+      it "marks itself as deleted" do
+        expect(@timestamp_category).to be_deleted
+      end
+
+      it "updates the timestamp" do
+        expect(@timestamp_category.updated_at).not_to eq @original_updated_at
       end
     end
   end

--- a/spec/soft_deletion_spec.rb
+++ b/spec/soft_deletion_spec.rb
@@ -27,12 +27,12 @@ describe SoftDeletion do
       it "removes the record and updates the timestamp" do
         original_updated_at = Time.now - 2.years
         category = TimestampCategory.create!(updated_at: original_updated_at)
-        expect(category.updated_at).to eq original_updated_at
+        expect(category.updated_at.to_i).to eq original_updated_at.to_i
 
         category.soft_delete!
         category.reload
         expect(category).to be_deleted
-        expect(category.updated_at).to be >= original_updated_at
+        expect(category.updated_at.to_i).to be >= original_updated_at.to_i
       end
     end
   end
@@ -509,16 +509,26 @@ describe SoftDeletion do
     end
   end
 
-  context "default_scope" do
+  context "scopes" do
     let(:forum) { Cat2Forum.create!(deleted_at: Time.now) }
 
-    it "prevents find when deleted" do
-      expect(Cat2Forum.find_by_id(forum.id)).to be_nil
+    context "default_scope" do
+      it "prevents find when deleted" do
+        expect(Cat2Forum.find_by_id(forum.id)).to be_nil
+      end
+
+      it "can find without deleted" do
+        forum.update(deleted_at: nil)
+        expect(Cat2Forum.find_by_id(forum.id)).not_to be_nil
+      end
     end
 
-    it "can find without deleted" do
-      forum.update(deleted_at: nil)
-      expect(Cat2Forum.find_by_id(forum.id)).not_to be_nil
+    context ".soft_deleted scope" do
+      let(:forum) { Cat2Forum.create!(deleted_at: Time.now) }
+
+      it "finds the soft_deleted object with soft_deleted scope" do
+        expect(Cat2Forum.soft_deleted.find_by_id(forum.id)).not_to be_nil
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -222,5 +222,5 @@ end
 class TimestampCategory  < ActiveRecord::Base
   self.table_name = 'categories'
 
-  has_soft_deletion(update_timestamp: true)
+  has_soft_deletion(update_timestamp: :updated_at)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(:version => 1) do
 
   create_table :categories do |t|
     t.timestamp :deleted_at
+    t.timestamp :updated_at
   end
 
   create_table :original_categories do |t|
@@ -216,4 +217,10 @@ class CCCategory < ActiveRecord::Base
   has_soft_deletion
 
   has_many :forums, class_name: 'CCForum', primary_key: 'id', foreign_key: 'category_id'
+end
+
+class TimestampCategory  < ActiveRecord::Base
+  self.table_name = 'categories'
+
+  has_soft_deletion(update_timestamp: true)
 end


### PR DESCRIPTION
Currently, `soft_deletion` does not update the `update_at` value in the soft-deleted records. This can cause some problems, for example if there is another application reading from database and checking for changes based on the timestamp. In this PR, I add an option so users can enable this feature.

```ruby
require 'soft_deletion'

class User < ActiveRecord::Base
  has_soft_deletion update_timestamp: true
end
```

Currently, this will only update `updated_at`. I could easily change this, so the timestamp column was customizable (`has_soft_deletion update_timestamp: [:my_customized_timestamp_column]`). What do you think?